### PR TITLE
balance.Fee -> balance.BtcUsdFee

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ func main() {
 	fmt.Println("\nAvailable Balances:")
 	fmt.Printf("USD %f\n", balance.UsdAvailable)
 	fmt.Printf("BTC %f\n", balance.BtcAvailable)
-	fmt.Printf("FEE %f\n\n", balance.Fee)
+	fmt.Printf("FEE %f\n\n", balance.BtcUsdFee)
 
 	// attempt to place a buy order
 	order, err := bitstamp.BuyLimitOrder(0.5, 600.00)


### PR DESCRIPTION
Fixing following compile error:
./bitstamp_check_balance.go:50:34: balance.Fee undefined (type *bitstamp.AccountBalanceResult has no field or method Fee)