### PR TITLE
error handling for case of wrong key

### DIFF
--- a/bitstamp.go
+++ b/bitstamp.go
@@ -19,9 +19,9 @@ var _cliId, _key, _secret string
 var _url string = "https://www.bitstamp.net/api/v2"
 
 type ErrorResult struct {
-	Status string `json:string`
-	Reason string `json:string`                                                                                                                                                             
-	Code   string `json:string`                                                                                                                                                             
+	Status string `json:"status,string"`
+	Reason string `json:"reason,string"`                                                                                                                                                             
+	Code   string `json:"code,string"`                                                                                                                                                             
 }
 
 type AccountBalanceResult struct {

--- a/bitstamp.go
+++ b/bitstamp.go
@@ -18,6 +18,12 @@ var _cliId, _key, _secret string
 
 var _url string = "https://www.bitstamp.net/api/v2"
 
+type ErrorResult struct {
+	Status string `json:string`
+	Reason string `json:string`                                                                                                                                                             
+	Code   string `json:string`                                                                                                                                                             
+}
+
 type AccountBalanceResult struct {
 	UsdBalance   float64 `json:"usd_balance,string"`
 	BtcBalance   float64 `json:"btc_balance,string"`
@@ -156,6 +162,13 @@ func privateQuery(path string, values url.Values, v interface{}) error {
 	err = json.Unmarshal(body, &e)
 	if bsEr, ok := e["error"]; ok {
 		return fmt.Errorf("%v", bsEr)
+	}
+
+	// Check for status == error
+	err_result := ErrorResult{}
+	json.Unmarshal(body,&err_result)
+	if err_result.Status == "error" {
+		return fmt.Errorf("%#v",err_result)
 	}
 
 	//parse the JSON response into the response object


### PR DESCRIPTION
This change allow privateQuery to handle properly case of server returning json error response.
Example use case is when user provide wrong key, then server returns `{"status": "error", "reason": "API key not found", "code": "API0001"}` however prior this commit code is proceeding like there was no error.
This change ensures, that we try to `json.Unmarshall` as Error first, and check against error.