### PR TITLE
Add AccountTransactions

### DIFF
--- a/AccountTransactionType.go
+++ b/AccountTransactionType.go
@@ -1,0 +1,70 @@
+package bitstamp
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	UserDeposit UserTransactionType = iota
+	UserWithdrawal
+	UserMarketTrade
+	UserSubAccountTransfer
+)
+
+type UserTransactionType int8
+
+func (t *UserTransactionType) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), "\"")
+	i, err := strconv.ParseInt(s, 10, 8)
+	*t = UserTransactionType(i)
+	return err
+}
+
+func (t UserTransactionType) String() string {
+	switch t {
+	case UserDeposit:
+		return "Deposit"
+	case UserWithdrawal:
+		return "Withdrawal"
+	case UserMarketTrade:
+		return "MarketTrade"
+	case UserSubAccountTransfer:
+		return "SubAccountTransfer"
+	default:
+		return ""
+	}
+}
+
+type accountTransactionsResult struct {
+	DateTime Time                `json:"datetime"`
+	Id       int64               `json:"id"`
+	Type     UserTransactionType `json:"type"`
+	Usd      Float               `json:"usd"`
+	Eur      Float               `json:"eur"`
+	Btc      Float               `json:"btc"`
+	Xrp      Float               `json:"xrp"`
+	Ltc      Float               `json:"ltc"`
+	Eth      Float               `json:"eth"`
+	BtcUsd   Float               `json:"btc_usd"`
+	UsdBtc   Float               `json:"usd_btc"`
+	Fee      Float               `json:"fee"`
+	OrderId  int64               `json:"order_id"`
+}
+
+type AccountTransactionResult struct {
+	DateTime time.Time           `json:"datetime"`
+	Id       int64               `json:"id"`
+	Type     UserTransactionType `json:"type"`
+	Usd      float64             `json:"usd"`
+	Eur      float64             `json:"eur"`
+	Btc      float64             `json:"btc"`
+	Xrp      float64             `json:"xrp"`
+	Ltc      float64             `json:"ltc"`
+	Eth      float64             `json:"eth"`
+	BtcUsd   float64             `json:"btc_usd"`
+	UsdBtc   float64             `json:"usd_btc"`
+	Fee      float64             `json:"fee"`
+	OrderId  int64               `json:"order_id"`
+}

--- a/account_transaction.go
+++ b/account_transaction.go
@@ -3,7 +3,6 @@ package bitstamp
 import (
 	"strconv"
 	"strings"
-	"time"
 )
 
 const (
@@ -37,8 +36,21 @@ func (t UserTransactionType) String() string {
 	}
 }
 
-type accountTransactionsResult struct {
-	DateTime Time                `json:"datetime"`
+type Float float64
+
+func (f *Float) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), "\"")
+	_f, err := strconv.ParseFloat(s, 64)
+	*f = Float(_f)
+	return err
+}
+
+// accountTransactionResult is used internally to ease the process of unmarshalling.
+// For some reason, for the transaction endpoint, Bitstamp is sends numbers
+// encoded as both strings and floats, intermingled. This means that we cannot
+// use the `json:"name,string"` automagic conversion here.
+type accountTransactionResult struct {
+	DateTime string              `json:"datetime"`
 	Id       int64               `json:"id"`
 	Type     UserTransactionType `json:"type"`
 	Usd      Float               `json:"usd"`
@@ -54,7 +66,7 @@ type accountTransactionsResult struct {
 }
 
 type AccountTransactionResult struct {
-	DateTime time.Time           `json:"datetime"`
+	DateTime string              `json:"datetime"`
 	Id       int64               `json:"id"`
 	Type     UserTransactionType `json:"type"`
 	Usd      float64             `json:"usd"`

--- a/bitstamp.go
+++ b/bitstamp.go
@@ -18,17 +18,6 @@ var _cliId, _key, _secret string
 
 var _url string = "https://www.bitstamp.net/api/v2"
 
-const bitstampTimeLayout = "2006-01-02 15:04:05"
-
-type Time time.Time
-
-func (t *Time) UnmarshalJSON(b []byte) error {
-	s := strings.Trim(string(b), "\"")
-	_t, err := time.Parse(bitstampTimeLayout, s)
-	*t = Time(_t)
-	return err
-}
-
 type ErrorResult struct {
 	Status string `json:"status,string"`
 	Reason string `json:"reason,string"`
@@ -88,7 +77,7 @@ type TickerResult struct {
 
 type BuyOrderResult struct {
 	Id       int64   `json:"id,string"`
-	DateTime Time    `json:"datetime"`
+	DateTime string  `json:"datetime"`
 	Type     int     `json:"type,string"`
 	Price    float64 `json:"price,string"`
 	Amount   float64 `json:"amount,string"`
@@ -96,7 +85,7 @@ type BuyOrderResult struct {
 
 type SellOrderResult struct {
 	Id       int64   `json:"id,string"`
-	DateTime Time    `json:"datetime"`
+	DateTime string  `json:"datetime"`
 	Type     int     `json:"type,string"`
 	Price    float64 `json:"price,string"`
 	Amount   float64 `json:"amount,string"`
@@ -115,20 +104,11 @@ type OrderBookItem struct {
 
 type OpenOrder struct {
 	Id           int64   `json:"id,string"`
-	DateTime     Time    `json:"datetime"`
+	DateTime     string  `json:"datetime"`
 	Type         int     `json:"type,string"`
 	Price        float64 `json:"price,string"`
 	Amount       float64 `json:"amount,string"`
 	CurrencyPair string  `json:"currency_pair"`
-}
-
-type Float float64
-
-func (f *Float) UnmarshalJSON(b []byte) error {
-	s := strings.Trim(string(b), "\"")
-	_f, err := strconv.ParseFloat(s, 64)
-	*f = Float(_f)
-	return err
 }
 
 func SetAuth(clientId, key, secret string) {
@@ -334,7 +314,7 @@ func OpenOrders() (*[]OpenOrder, error) {
 }
 
 func AccountTransactions() ([]AccountTransactionResult, error) {
-	internalTs := make([]accountTransactionsResult, 0)
+	internalTs := make([]accountTransactionResult, 0)
 	err := privateQuery("/user_transactions/", url.Values{}, &internalTs)
 	if err != nil {
 		return nil, err
@@ -343,7 +323,7 @@ func AccountTransactions() ([]AccountTransactionResult, error) {
 	ts := make([]AccountTransactionResult, len(internalTs))
 	for i, t := range internalTs {
 		ts[i] = AccountTransactionResult{
-			DateTime: time.Time(t.DateTime),
+			DateTime: t.DateTime,
 			Id:       t.Id,
 			Type:     t.Type,
 			Usd:      float64(t.Usd),


### PR DESCRIPTION
Hello,

I added the AccountTransactions endpoint.

It is somewhat convoluted compared to the rest of the endpoints. The reason is explained in my comment over the `accountTransactionResult` type.

An example of inconsistent data returned by Bitstamp:
```
{
	"fee": "0.00000000",
	"order_id": 294995485,
	"eth_btc": 0.06907000,
	"datetime": "2017-09-15 15:52:47",
	"usd": 0.0,
	"btc": "0.01602514",
	"eth": "-0.23201300",
	"type": "2",
	"id": 21435498,
	"eur": 0.0  // <---
}, {
	"fee": "0.00",
	"order_id": 294984225,
	"datetime": "2017-09-15 15:46:53",
	"usd": 0.0,
	"btc": "0.03200000",
	"btc_eur": 3125.00000000,
	"type": "2",
	"id": 21433500,
	"eur": "-100.00"  // <---
}, {
	"fee": "0.00",
	"order_id": 294977112,
	"datetime": "2017-09-15 15:43:24",
	"usd": 0.0,
	"btc": 0.0,
	"eth": "0.46403712",
	"eth_eur": 215.30000000,
	"type": "2",
	"id": 21432376,
	"eur": "-99.91"  // <---
},
```

Here, we see that the `"eur"` property is returned both as a number and as a string.
  