### PR TITLE
Missing channel attribute to bitstamp.Event data struct

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -19,8 +19,9 @@ type WebSocket struct {
 }
 
 type Event struct {
-	Event string      `json:"event"`
-	Data  interface{} `json:"data"`
+	Event   string      `json:"event"`
+	Channel string      `json:"channel"`
+	Data    interface{} `json:"data"`
 }
 
 func (s *WebSocket) Close() {


### PR DESCRIPTION
Problem:

When subscribing to multiple channels there was no way to know from
which channel the published/received data was coming from.

We may want to subscribe to multiple channels, for example
"live_trades_btcusd", "live_trades_ethbtc", etc.

We need a way to know from which channel the message is coming from.